### PR TITLE
Add new aws certificate to echos

### DIFF
--- a/cloudformation/alb-external-methode-restapi.yaml
+++ b/cloudformation/alb-external-methode-restapi.yaml
@@ -121,7 +121,7 @@ Resources:
       Port: 443
       Protocol: HTTPS
       Certificates:
-        - CertificateArn: arn:aws:acm:eu-west-1:307921801440:certificate/00b98d3d-2c61-4a52-a28c-5bbb79c04011
+        - CertificateArn: arn:aws:acm:eu-west-1:307921801440:certificate/24f4f6a8-6a56-48ad-82be-de69b0221ae3
   ListenerRuleAdOrder:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:

--- a/cloudformation/alb-external-methode.yaml
+++ b/cloudformation/alb-external-methode.yaml
@@ -124,7 +124,7 @@ Resources:
       Port: 443
       Protocol: HTTPS
       Certificates:
-        - CertificateArn: arn:aws:acm:eu-west-1:307921801440:certificate/00b98d3d-2c61-4a52-a28c-5bbb79c04011      
+        - CertificateArn: arn:aws:acm:eu-west-1:307921801440:certificate/24f4f6a8-6a56-48ad-82be-de69b0221ae3    
 Outputs:
   LoadBalancerDNSName:
     Description: Load Balancer DNS Name

--- a/tasks/echoes/echoes-service-alb.yaml
+++ b/tasks/echoes/echoes-service-alb.yaml
@@ -6,7 +6,7 @@ Parameters:
     Type: String
     Description: >
       Specifies SSL Certificate used on Load Balancer
-    Default: arn:aws:acm:eu-west-1:307921801440:certificate/00b98d3d-2c61-4a52-a28c-5bbb79c04011
+    Default: arn:aws:acm:eu-west-1:307921801440:certificate/24f4f6a8-6a56-48ad-82be-de69b0221ae3
   EcsClusterName:
     Type: String
     Description: >
@@ -112,7 +112,7 @@ Resources:
       Port: 443
       Protocol: HTTPS
       Certificates:
-        - CertificateArn: arn:aws:acm:eu-west-1:307921801440:certificate/00b98d3d-2c61-4a52-a28c-5bbb79c04011
+        - CertificateArn: arn:aws:acm:eu-west-1:307921801440:certificate/24f4f6a8-6a56-48ad-82be-de69b0221ae3
 Outputs:
   LoadBalancerDNSName:
     Description: Load Balancer DNS Name

--- a/tasks/echoes/echoes-service-nlb.yaml
+++ b/tasks/echoes/echoes-service-nlb.yaml
@@ -6,7 +6,7 @@ Parameters:
     Type: String
     Description: >
       Specifies SSL Certificate used on Load Balancer
-    Default: arn:aws:acm:eu-west-1:307921801440:certificate/00b98d3d-2c61-4a52-a28c-5bbb79c04011
+    Default: arn:aws:acm:eu-west-1:307921801440:certificate/24f4f6a8-6a56-48ad-82be-de69b0221ae3
   EcsClusterName:
     Type: String
     Description: >


### PR DESCRIPTION
A request came from CE team because the old DigiCert will expire in 31 days; the new alternative is managed by AWS.

Updated the certificate we using with the new aws one.